### PR TITLE
Deposits associated with budgets

### DIFF
--- a/budgetapi/models/deposit.py
+++ b/budgetapi/models/deposit.py
@@ -1,7 +1,7 @@
 from django.db import models
 
 class Deposit(models.Model):
-    budget=models.ForeignKey("Budget", on_delete=models.CASCADE)
+    budget=models.ForeignKey("Budget", on_delete=models.CASCADE, related_name="income")
     source=models.CharField(max_length=50)
     amount=models.FloatField()
     date=models.DateTimeField(auto_now=False, auto_now_add=False)

--- a/budgetapi/views/budgets.py
+++ b/budgetapi/views/budgets.py
@@ -43,4 +43,5 @@ class Budgets(ViewSet):
 class BudgetSerializer(serializers.ModelSerializer):
     class Meta: 
         model = Budget
-        fields = ('user', 'month', 'year', 'est_income')
+        fields = ('user', 'month', 'year', 'est_income', 'income')
+        depth = 1


### PR DESCRIPTION
# Description
added a relate_name to deposits and included the related name in the fields of the serializer for budgets, so that when requesting budgets the client also receives all related income
## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
