### PR TITLE
Show only users bills

### DIFF
--- a/budgetapi/views/recurringBills.py
+++ b/budgetapi/views/recurringBills.py
@@ -54,8 +54,9 @@ class PaymentSerializer(serializers.ModelSerializer):
         model = Payment
         fields = ('id', 'amount', 'date_paid', 'budget_id')
 
+
 class RecurringBillSerializer(serializers.ModelSerializer):
     class Meta:
         model = RecurringBill
-        fields = ('id', 'biller', 'expected_amount', 'due_date', 'payments')
+        fields = ('id', 'biller', 'user', 'expected_amount', 'due_date', 'payments')
         depth = 1


### PR DESCRIPTION
# Description
added the user field to the recurringbillserializer so that the client can verify only the currently logged in users bills are displayed
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
