### PR TITLE
Only return related purchases

### DIFF
--- a/budgetapi/views/budgets.py
+++ b/budgetapi/views/budgets.py
@@ -69,7 +69,7 @@ class Budgets(ViewSet):
                 except TypeError:
                     total_spent = 0
                 for envelope in related_envelopes:
-                    payments = GeneralExpense.objects.filter(envelope = envelope)
+                    payments = GeneralExpense.objects.filter(envelope = envelope, budget = budget)
                     try:
                         payment_total=payments.aggregate(Sum('amount'))
                         total_spent += payment_total['amount__sum']
@@ -117,7 +117,7 @@ class Budgets(ViewSet):
             except TypeError:
                 total_spent = 0
             for envelope in related_envelopes:
-                payments = GeneralExpense.objects.filter(envelope = envelope)
+                payments = GeneralExpense.objects.filter(envelope = envelope, budget = budget)
                 try:
                     payment_total=payments.aggregate(Sum('amount'))
                     total_spent += payment_total['amount__sum']


### PR DESCRIPTION
# Description
refactored the retrieve and list methods for budgets so that they only get associated payments for that budget and not all payments
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
